### PR TITLE
[updated] chinese characters regex

### DIFF
--- a/lib/rules/no-chinese-character.js
+++ b/lib/rules/no-chinese-character.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-	var regex = /[\u4E00-\u9FA5]/;
+	var regex = /[\u4E00-\u9FFF]/;
 	var report = function (node, val) {
 		context.report({
 			node: node,


### PR DESCRIPTION
The range of CJK Unified Ideographs is 4E00 to 9FFF.
Unicode versions piror to 4.1 actually allocate code points up to 9FA5.
Unicode 13.0 (current latest versions) actually allocates code points up to 9FFC.
This commit uses 9FFF for forward compatibility.

For implementation simplicity,
this regex will not detect characters in
CJK Unified Ideographs Extension A-G.
