### PR TITLE
[added] an option to support callee.excludes

### DIFF
--- a/docs/rules/no-chinese-character.md
+++ b/docs/rules/no-chinese-character.md
@@ -49,3 +49,16 @@ The rule takes an object option with the following keys:
   }
 ]
 ```
+
+### {array} `excludeArgsForFunctions`
+
+* We exclude from the check the functions specified in the `excludeArgsForFunctions` option.
+
+```json
+"i18n/no-chinese-character": [
+  "warn",
+  {
+    "excludeArgsForFunctions": ["i18n", "l10n"]
+  }
+]
+```

--- a/docs/rules/no-greek-character.md
+++ b/docs/rules/no-greek-character.md
@@ -49,3 +49,16 @@ The rule takes an object option with the following keys:
   }
 ]
 ```
+
+### {array} `excludeArgsForFunctions`
+
+* We exclude from the check the functions specified in the `excludeArgsForFunctions` option.
+
+```json
+"i18n/no-greek-character": [
+  "warn",
+  {
+    "excludeArgsForFunctions": ["i18n", "l10n"]
+  }
+]
+```

--- a/docs/rules/no-japanese-character.md
+++ b/docs/rules/no-japanese-character.md
@@ -49,3 +49,16 @@ The rule takes an object option with the following keys:
   }
 ]
 ```
+
+### {array} `excludeArgsForFunctions`
+
+* We exclude from the check the functions specified in the `excludeArgsForFunctions` option.
+
+```json
+"i18n/no-japanese-character": [
+  "warn",
+  {
+    "excludeArgsForFunctions": ["i18n", "l10n"]
+  }
+]
+```

--- a/docs/rules/no-korean-character.md
+++ b/docs/rules/no-korean-character.md
@@ -49,3 +49,16 @@ The rule takes an object option with the following keys:
   }
 ]
 ```
+
+### {array} `excludeArgsForFunctions`
+
+* We exclude from the check the functions specified in the `excludeArgsForFunctions` option.
+
+```json
+"i18n/no-korean-character": [
+  "warn",
+  {
+    "excludeArgsForFunctions": ["i18n", "l10n"]
+  }
+]
+```

--- a/docs/rules/no-russian-character.md
+++ b/docs/rules/no-russian-character.md
@@ -49,3 +49,16 @@ The rule takes an object option with the following keys:
   }
 ]
 ```
+
+### {array} `excludeArgsForFunctions`
+
+* We exclude from the check the functions specified in the `excludeArgsForFunctions` option.
+
+```json
+"i18n/no-russian-character": [
+  "warn",
+  {
+    "excludeArgsForFunctions": ["i18n", "l10n"]
+  }
+]
+```

--- a/docs/rules/no-thai-character.md
+++ b/docs/rules/no-thai-character.md
@@ -49,3 +49,16 @@ The rule takes an object option with the following keys:
   }
 ]
 ```
+
+### {array} `excludeArgsForFunctions`
+
+* We exclude from the check the functions specified in the `excludeArgsForFunctions` option.
+
+```json
+"i18n/no-thai-character": [
+  "warn",
+  {
+    "excludeArgsForFunctions": ["i18n", "l10n"]
+  }
+]
+```

--- a/lib/utils/define.js
+++ b/lib/utils/define.js
@@ -24,12 +24,18 @@ module.exports = function(lang, regex) {
             type: 'boolean',
             default: false,
           },
+          excludeArgsForFunctions: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
         },
         additionalProperties: false,
       }],
     },
     create: function(context) {
-      const { includeIdentifier, includeComment } = context.options[0] || {};
+      const { includeIdentifier, includeComment, excludeArgsForFunctions } = context.options[0] || {};
       const report = function(node, val) {
         context.report({
           node: node,
@@ -42,11 +48,23 @@ module.exports = function(lang, regex) {
 
       const listeners = {
         'Literal, JSXText': function(node) {
+          if (typeof excludeArgsForFunctions === 'object') {
+            if (node.parent.type === 'CallExpression' && excludeArgsForFunctions.some((value) => value === node.parent.callee.name)) {
+              return;
+            }
+          }
+
           if (typeof node.value === 'string' && regex.exec(node.raw)) {
             report(node, node.raw);
           }
         },
         'TemplateElement': function(node) {
+          if (typeof excludeArgsForFunctions === 'object') {
+            if (node.parent.parent.type === 'CallExpression' && excludeArgsForFunctions.some((value) => value === node.parent.parent.callee.name)) {
+              return;
+            }
+          }
+
           const v = node.value;
           if (v && v.raw && regex.exec(v.raw)) {
             report(node, v.raw);

--- a/tests/lib/rules/no-chinese-character.js
+++ b/tests/lib/rules/no-chinese-character.js
@@ -40,6 +40,27 @@ ruleTester.run('no-chinese-character', rule, {
         sourceType: 'module',
       },
     },
+    {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{dic(\'函式\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: 'var tl = dic(`樣板字串`)',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+      },
+    },
   ],
   invalid: [
     {
@@ -56,12 +77,37 @@ ruleTester.run('no-chinese-character', rule, {
       }],
     },
     {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{func(\'函式\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [{
+        message: 'Using Chinese characters: \'函式\'', type: 'Literal',
+      }],
+    },
+    {
       code: 'var str = `樣板字串`; console.log(`${str}、模板字符串`);',
       env: { es6: true },
       errors: [{
         message: 'Using Chinese characters: 樣板字串', type: 'TemplateElement',
       }, {
         message: 'Using Chinese characters: 、模板字符串', type: 'TemplateElement',
+      }],
+    },
+    {
+      code: 'var tl = func(`樣板字串`)',
+      env: { es6: true },
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      errors: [{
+        message: 'Using Chinese characters: 樣板字串',
+        type: 'TemplateElement',
       }],
     },
     {

--- a/tests/lib/rules/no-greek-character.js
+++ b/tests/lib/rules/no-greek-character.js
@@ -40,6 +40,27 @@ ruleTester.run('no-greek-character', rule, {
         sourceType: 'module',
       },
     },
+    {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{dic(\'λειτουργία\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: 'var tl = dic(`συμβολοσειρές`)',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+      },
+    },
   ],
   invalid: [
     {
@@ -56,9 +77,34 @@ ruleTester.run('no-greek-character', rule, {
       }],
     },
     {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{func(\'λειτουργία\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [{
+        message: 'Using Greek characters: \'λειτουργία\'', type: 'Literal',
+      }],
+    },
+    {
       code: 'var str = `συμβολοσειρές`',
       env: { es6: true },
       errors: [{ message: 'Using Greek characters: συμβολοσειρές', type: 'TemplateElement' }],
+    },
+    {
+      code: 'var tl = func(`συμβολοσειρές`)',
+      env: { es6: true },
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      errors: [{
+        message: 'Using Greek characters: συμβολοσειρές',
+        type: 'TemplateElement',
+      }],
     },
     {
       code: 'console.log(\'english\' + \'Ελληνικά\');',

--- a/tests/lib/rules/no-japanese-character.js
+++ b/tests/lib/rules/no-japanese-character.js
@@ -40,6 +40,27 @@ ruleTester.run('no-japanese-character', rule, {
         sourceType: 'module',
       },
     },
+    {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{dic(\'関数\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: 'var tl = dic(`テンプレート文字列`)',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+      },
+    },
   ],
   invalid: [
     {
@@ -56,8 +77,33 @@ ruleTester.run('no-japanese-character', rule, {
       }],
     },
     {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{func(\'関数\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [{
+        message: 'Using Japanese characters: \'関数\'', type: 'Literal',
+      }],
+    },
+    {
       code: 'var tl = `テンプレート文字列`',
       env: { es6: true },
+      errors: [{
+        message: 'Using Japanese characters: テンプレート文字列',
+        type: 'TemplateElement',
+      }],
+    },
+    {
+      code: 'var tl = func(`テンプレート文字列`)',
+      env: { es6: true },
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
       errors: [{
         message: 'Using Japanese characters: テンプレート文字列',
         type: 'TemplateElement',

--- a/tests/lib/rules/no-korean-character.js
+++ b/tests/lib/rules/no-korean-character.js
@@ -40,6 +40,27 @@ ruleTester.run('no-korean-character', rule, {
         sourceType: 'module',
       },
     },
+    {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{dic(\'함수\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: 'var tl = dic(`템플릿 문자열`)',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+      },
+    },
   ],
   invalid: [
     {
@@ -56,9 +77,34 @@ ruleTester.run('no-korean-character', rule, {
       }],
     },
     {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{func(\'함수\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [{
+        message: 'Using Korean characters: \'함수\'', type: 'Literal',
+      }],
+    },
+    {
       code: 'var tl = `템플릿 문자열`',
       env: { es6: true },
       errors: [{ message: 'Using Korean characters: 템플릿 문자열', type: 'TemplateElement' }],
+    },
+    {
+      code: 'var tl = func(`템플릿 문자열`)',
+      env: { es6: true },
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      errors: [{
+        message: 'Using Korean characters: 템플릿 문자열',
+        type: 'TemplateElement',
+      }],
     },
     {
       code: 'console.log(\'english\' + \'한국어\');',

--- a/tests/lib/rules/no-russian-character.js
+++ b/tests/lib/rules/no-russian-character.js
@@ -40,6 +40,27 @@ ruleTester.run('no-russian-character', rule, {
         sourceType: 'module',
       },
     },
+    {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{dic(\'Функции\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: 'var tl = dic(`Шаблонные строки`)',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+      },
+    },
   ],
   invalid: [
     {
@@ -56,8 +77,33 @@ ruleTester.run('no-russian-character', rule, {
       }],
     },
     {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{func(\'Функции\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [{
+        message: 'Using Russian characters: \'Функции\'', type: 'Literal',
+      }],
+    },
+    {
       code: 'var tl = `Шаблонные строки`',
       env: { es6: true },
+      errors: [{
+        message: 'Using Russian characters: Шаблонные строки',
+        type: 'TemplateElement',
+      }],
+    },
+    {
+      code: 'var tl = func(`Шаблонные строки`)',
+      env: { es6: true },
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
       errors: [{
         message: 'Using Russian characters: Шаблонные строки',
         type: 'TemplateElement',

--- a/tests/lib/rules/no-thai-character.js
+++ b/tests/lib/rules/no-thai-character.js
@@ -40,6 +40,27 @@ ruleTester.run('no-thai-character', rule, {
         sourceType: 'module',
       },
     },
+    {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{dic(\'ฟังก์ชัน\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: 'var tl = dic(`อักษรแม่แบบ`)',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+      },
+    },
   ],
   invalid: [
     {
@@ -56,9 +77,34 @@ ruleTester.run('no-thai-character', rule, {
       }],
     },
     {
+      code: 'var func = function(v){return v;}; var tpl = <Hello>{func(\'ฟังก์ชัน\')}</Hello>;',
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [{
+        message: 'Using Thai characters: \'ฟังก์ชัน\'', type: 'Literal',
+      }],
+    },
+    {
       code: 'var tl = `อักษรแม่แบบ`',
       env: { es6: true },
       errors: [{ message: 'Using Thai characters: อักษรแม่แบบ', type: 'TemplateElement' }],
+    },
+    {
+      code: 'var tl = func(`อักษรแม่แบบ`)',
+      env: { es6: true },
+      options: [{
+        excludeArgsForFunctions: ['dic'],
+      }],
+      errors: [{
+        message: 'Using Thai characters: อักษรแม่แบบ',
+        type: 'TemplateElement',
+      }],
     },
     {
       code: 'console.log(\'english\' + \'ไทย\');',


### PR DESCRIPTION
## Background

There are cases where i18n dictionary keys are managed in Japanese. 

```json
{
  "こんにちは": "こんにちは",
  "おはよう": "おはよう",
   ...
}
```

In this case, your plugin outputs the value as an error even if it goes through the function to get the value from the dictionary.

```ts
const internationalizedText = i18n('こんにちは') // ← i18n() is a function to get a value from a dictionary, so we want to avoid detection by Linter
```

## Changes

Added `callee.excludes` option to set functions to be excluded from checking by this plugin's rules.

### Usage

```
i18n/no-japanese-character": [
  "error",
  {
    "callee": {
      "excludes": ["i18n"]
    }
  }
]
```

With this configuration, Linter will behave as follows.

```ts
const internationalizedText = i18n('こんにちは') -> OK
const message = getMessage('こんにちは') -> NG
```